### PR TITLE
Add VIDEO modality to Modality class

### DIFF
--- a/src/python_open_router/models.py
+++ b/src/python_open_router/models.py
@@ -106,26 +106,6 @@ class Modality(StrEnum):
     EMBEDDINGS = "embeddings"
     VIDEO = "video"
 
-    @classmethod
-    def _missing_(cls, value):
-        if value is None:
-            raise ValueError("Modality missing")
-        v = str(value).strip().lower()
-        map_table = {
-            "file": cls.FILE,
-            "files": cls.FILE,
-            "audio": cls.AUDIO,
-            "sound": cls.AUDIO,
-            "video": cls.VIDEO,
-            "vid": cls.VIDEO,
-            "text": cls.TEXT,
-            "image": cls.IMAGE,
-            "img": cls.IMAGE,
-        }
-        if v in map_table:
-            return map_table[v]
-        raise ValueError(f"Unknown modality: {value!r}")
-
 
 @dataclass(kw_only=True)
 class ModelArchitecture(DataClassORJSONMixin):


### PR DESCRIPTION
Add VIDEO modality and handle it in _missing_ method

The current open router integration within home assistant is not working due to missing modality.

# Proposed Changes

> Adding Video modaility and a fallback for the future.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://github.com/joostlek/python-open-router/issues/165
